### PR TITLE
Add Python 3.6 to tox build matrix

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35
+envlist = py{27,35,36}
 [testenv]
 deps=pytest
 commands=py.test --junitxml=junit-{envname}.xml


### PR DESCRIPTION
Some of our services will be using python 3.6 so we should make sure to test
using that version as well.