### PR TITLE
Allow parsing empty relationship objects

### DIFF
--- a/json_api_mapper/json_api_mapper.py
+++ b/json_api_mapper/json_api_mapper.py
@@ -69,9 +69,10 @@ class JsonApiMapper(with_metaclass(JsonApiMapperMeta, object)):
                 related_type = relationsship_data.get("type", None)
                 related_id = relationsship_data.get("id", None)
                 return key_mapper.get((related_type, related_id), relationsship_data)
-            item[key] = cls._apply_once_or_many(value["data"], do)
-            if "meta" in value:
-                item[key+"_meta"] = value["meta"]
+            if value:
+                item[key] = cls._apply_once_or_many(value["data"], do)
+                if "meta" in value:
+                    item[key+"_meta"] = value["meta"]
 
     @classmethod
     def _apply_once_or_many(cls, data, func):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='json_api_mapper',
-      version='0.0.1',
+      version='0.0.2',
       description='JSON API mapper',
       url='https://github.com/kundo/json_api_mapper',
       author='Kundo',

--- a/tests/test_json_api_mapper.py
+++ b/tests/test_json_api_mapper.py
@@ -110,6 +110,34 @@ class JsonApiMapperTest(TestCase):
         )
         self.assertEqual(actual, expected)
 
+    def test_with_relationships__with_empty_relations(self):
+        api_json = {
+            "data": {
+                "id": "asd",
+                "type": "test",
+                "attributes": {
+                    "content": "hej hej",
+                    "title": "a title",
+                    "some_special_value": 4711,
+                },
+                "relationships": {"parent": {}}
+            },
+            "included": []
+        }
+
+        actual = JsonApiMapper.from_json(api_json)
+
+        expected = dict(
+            id="asd",
+            content="hej hej",
+            title="a title",
+            public_url=None,
+            special=4711,
+        )
+
+        assert actual == expected
+
+
     def test_with_multiple_related_objects_and_meta(self):
         api_json = {
             "data": {


### PR DESCRIPTION
If we get `relationships: { foo: {} }`, the parser should not explode.